### PR TITLE
リールを1コマずつ追加できるように変更

### DIFF
--- a/slokara/slokara.xcodeproj/project.pbxproj
+++ b/slokara/slokara.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		6A68CA0E242A3F4B0047F413 /* Probability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68CA0D242A3F4B0047F413 /* Probability.swift */; };
 		6A68CA10242A49110047F413 /* ProbabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68CA0F242A49110047F413 /* ProbabilityTests.swift */; };
 		6A68CA13242F97900047F413 /* UserStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68CA12242F97900047F413 /* UserStatus.swift */; };
+		6A8BEB80244DD67A00142587 /* Reel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8BEB7F244DD67A00142587 /* Reel.swift */; };
+		6A8BEB82244DDA5900142587 /* ReelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8BEB81244DDA5900142587 /* ReelTest.swift */; };
 		6ABF318A23AF586A0014E0BD /* TaskListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABF318923AF586A0014E0BD /* TaskListViewController.swift */; };
 		6ABF318C23AF58780014E0BD /* TaskList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6ABF318B23AF58780014E0BD /* TaskList.storyboard */; };
 		6ABF318E23AF59570014E0BD /* TaskListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABF318D23AF59570014E0BD /* TaskListViewModel.swift */; };
@@ -134,6 +136,8 @@
 		6A68CA0D242A3F4B0047F413 /* Probability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Probability.swift; sourceTree = "<group>"; };
 		6A68CA0F242A49110047F413 /* ProbabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbabilityTests.swift; sourceTree = "<group>"; };
 		6A68CA12242F97900047F413 /* UserStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStatus.swift; sourceTree = "<group>"; };
+		6A8BEB7F244DD67A00142587 /* Reel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reel.swift; sourceTree = "<group>"; };
+		6A8BEB81244DDA5900142587 /* ReelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReelTest.swift; sourceTree = "<group>"; };
 		6ABF318923AF586A0014E0BD /* TaskListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListViewController.swift; sourceTree = "<group>"; };
 		6ABF318B23AF58780014E0BD /* TaskList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TaskList.storyboard; sourceTree = "<group>"; };
 		6ABF318D23AF59570014E0BD /* TaskListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListViewModel.swift; sourceTree = "<group>"; };
@@ -356,6 +360,7 @@
 				6A63B27B2402B2EB00B8719D /* UserParameter.swift */,
 				6A68CA0B242A3CF50047F413 /* Stage.swift */,
 				6A68CA0D242A3F4B0047F413 /* Probability.swift */,
+				6A8BEB7F244DD67A00142587 /* Reel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -414,6 +419,7 @@
 				6A68CA0F242A49110047F413 /* ProbabilityTests.swift */,
 				6A5142AB2430729900791D9F /* UserStatusTest.swift */,
 				6A5A8A50243CCD6000F8A829 /* Array+Test.swift */,
+				6A8BEB81244DDA5900142587 /* ReelTest.swift */,
 			);
 			path = slokaraTests;
 			sourceTree = "<group>";
@@ -740,6 +746,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A5A8A4A2436228000F8A829 /* ClearedModel.swift in Sources */,
+				6A8BEB80244DD67A00142587 /* Reel.swift in Sources */,
 				6A599E992427D5C700067D7A /* BattleProgressView.swift in Sources */,
 				6ABF319023AF59660014E0BD /* TaskListModel.swift in Sources */,
 				98367115239810F200F590ED /* NavigationViewModel.swift in Sources */,
@@ -790,6 +797,7 @@
 				9821B3452378560400CF964D /* slokaraTests.swift in Sources */,
 				6A5A8A51243CCD6000F8A829 /* Array+Test.swift in Sources */,
 				6A68CA10242A49110047F413 /* ProbabilityTests.swift in Sources */,
+				6A8BEB82244DDA5900142587 /* ReelTest.swift in Sources */,
 				6A5142AC2430729900791D9F /* UserStatusTest.swift in Sources */,
 				6A5A8A52243CCF6900F8A829 /* Array+.swift in Sources */,
 			);

--- a/slokara/slokara/Battle/BattleViewModel.swift
+++ b/slokara/slokara/Battle/BattleViewModel.swift
@@ -6,6 +6,7 @@ final class BattleViewModel {
     private let disposeBag = DisposeBag()
     
     // ここはDBから取得する
+    let reel = Reel(top: [true, true, true], center: [false, true, true], bottom: [true, false, true])
     private let reelLine = ReelLine.triple
     private var userParameter: UserParameter!
     
@@ -23,7 +24,7 @@ final class BattleViewModel {
     var numberOfEnemy: Observable<Int>!
    
     let reelStart: Observable<Void>
-    var reelActionResults: Observable<[AttributeType]>!
+    var reelActionResults: Observable<[AttributeType?]>!
     
     // プレイヤーの攻撃
     private let playerAttackRelay = PublishRelay<Int64>()
@@ -49,13 +50,13 @@ final class BattleViewModel {
     private let stageClearRelay = PublishRelay<Void>()
     var stageClear: Observable<Void> { return self.stageClearRelay.asObservable() }
     
-    init(screenTaped: Observable<Bool>, reelStoped: Observable<[AttributeType]>, playerAttacked: Observable<Int64>, requestNextEnemy: Observable<Void>, battleModel: BattleModelProtocol) {
+    init(screenTaped: Observable<Bool>, reelStoped: Observable<[AttributeType?]>, playerAttacked: Observable<Int64>, requestNextEnemy: Observable<Void>, battleModel: BattleModelProtocol) {
         self.battleModel = battleModel
 
         self.reelStart = screenTaped.filter{ !$0 }.map{_ in }.throttle(RxTimeInterval.seconds(1), latest: false, scheduler: MainScheduler.instance)
         
         self.reelActionResults = screenTaped.filter{ $0 }.throttle(RxTimeInterval.seconds(1), latest: false, scheduler: MainScheduler.instance).map{ [unowned self] _ in
-            [Probability](repeating: self.enemy.probability, count: self.reelLine.numberOfCharacter).map{prob in prob.randomElement() }
+            self.reel.enableLines.flatMap{ $0 }.map{ $0 ? self.enemy.probability.randomElement() : nil }
         }
         
         self.battleModel.userParameter.subscribe(onNext: { [weak self] param in
@@ -80,7 +81,7 @@ final class BattleViewModel {
         }).disposed(by: disposeBag)
     }
     
-    private func acceptAttack(results: [AttributeType]) {
+    private func acceptAttack(results: [AttributeType?]) {
         let attackPower = calculateAttackPower(result: results, line: self.reelLine)
         self.playerAttackRelay.accept(attackPower.player)
         
@@ -101,41 +102,33 @@ final class BattleViewModel {
     }
     
     /*
-     シングルライン、ダブルラインは横ラインのみ有効
-     トリプルラインは縦横斜めのラインが有効
+     縦、横、斜めの2つ以上連続して並んでいるラインが有効ライン
      */
-    private func calculateAttackPower(result: [AttributeType], line: ReelLine) -> (player: Int64, enemy: Int64) {
-        switch line {
-        case .single:
-            let attacks = singleLineCalaulation(list: result)
-            let player = attacks.0 - self.enemy.defense
-            let enemyAttack = attacks.1 - self.userParameter.defense
-            return (player > 0 ? player : 0, enemyAttack > 0 ? enemyAttack : 0)
-
-        case .double:
-            guard result.count == 6 else { assert(false, "No match reel lines"); return (0, 0) }
-            let topAttack = singleLineCalaulation(list: Array(result[0...2]))
-            let bottomAttack = singleLineCalaulation(list: Array(result[3...5]))
-            let player = topAttack.0 + bottomAttack.0 - self.enemy.defense
-            let enemyAttack = topAttack.1 + bottomAttack.1 - self.userParameter.defense
-            return (player > 0 ? player : 0, enemyAttack > 0 ? enemyAttack : 0)
-
-        case .triple:
-            guard result.count == 9 else { assert(false, "No match reel lines"); return (0, 0) }
-            let topAttack = singleLineCalaulation(list: Array(result[0...2]))
-            let middleAttack = singleLineCalaulation(list: Array(result[3...5]))
-            let bottomAttack = singleLineCalaulation(list: Array(result[6...8]))
-            let leftAttack = singleLineCalaulation(list: [result[0], result[3], result[6]])
-            let centerAttack = singleLineCalaulation(list: [result[1], result[4], result[7]])
-            let rightAttack = singleLineCalaulation(list: [result[2], result[5], result[8]])
-            let leftDiagonalAttack = singleLineCalaulation(list: [result[0], result[4], result[8]])
-            let rightDiagonalAttack = singleLineCalaulation(list: [result[2], result[4], result[6]])
-            let attackList = [topAttack, middleAttack, bottomAttack, leftAttack, centerAttack, rightAttack, leftDiagonalAttack, rightDiagonalAttack]
-            let attacks = attackList.reduce((0, 0)) { ($0.0 + $1.0, $0.1 + $1.1) }
-            let player = attacks.0 - self.enemy.defense
-            let enemyAttack = attacks.1 - self.userParameter.defense
-            return (player > 0 ? player : 0, enemyAttack > 0 ? enemyAttack : 0)
+    private func calculateAttackPower(result: [AttributeType?], line: ReelLine) -> (player: Int64, enemy: Int64) {
+        guard result.count.isMultiple(of: 3) else { assert(false, "No Match charactors."); return (0, 0) }
+        
+        // 計算メソッドでのOutOfIndexを避ける為、リールの不足分をnil埋めする
+        var result = result
+        while result.count < 9 {
+            result.append(nil)
         }
+        
+        let chars = result.separate(of: 3)
+
+        let topAttack = singleLineCalaulation(list: chars[0])
+        let middleAttack = singleLineCalaulation(list: chars[1])
+        let bottomAttack = singleLineCalaulation(list: chars[2])
+        let leftAttack = singleLineCalaulation(list: [chars[0][0], chars[1][0], chars[2][0]])
+        let centerAttack = singleLineCalaulation(list: [chars[0][1], chars[1][1], chars[2][1]])
+        let rightAttack = singleLineCalaulation(list: [chars[0][2], chars[1][2], chars[2][2]])
+        let leftDiagonalAttack = singleLineCalaulation(list: [chars[0][0], chars[1][1], chars[2][2]])
+        let rightDiagonalAttack = singleLineCalaulation(list: [chars[0][2], chars[1][1], chars[2][0]])
+        let attackList = [topAttack, middleAttack, bottomAttack, leftAttack, centerAttack, rightAttack, leftDiagonalAttack, rightDiagonalAttack]
+        let attacks = attackList.reduce((0, 0)) { ($0.0 + $1.0, $0.1 + $1.1) }
+        let player = attacks.0 - self.enemy.defense
+        let enemyAttack = attacks.1 - self.userParameter.defense
+
+        return (player > 0 ? player : 0, enemyAttack > 0 ? enemyAttack : 0)
     }
     
     /*
@@ -168,30 +161,34 @@ final class BattleViewModel {
         攻撃:(5*2 + 5*2)*1.2 + 5*0.8 = 28
         敵に与えるダメージ:28-10 = 18
      */
-    private func singleLineCalaulation(list: [AttributeType]) -> (Int64, Int64) {
+    private func singleLineCalaulation(list: [AttributeType?]) -> (Int64, Int64) {
         guard list.count == 3 else { assert(false, "No match reel chars"); return (0, 0) }
+        // ラインの真ん中がnil、または2つ以上がnilなら無効ライン
+        guard list.filter({ $0 == nil }).count < 2 , list[1] != nil else { return (0, 0) }
+        
         var attacks = AttributeType.allCases.map {_ in Int64(0) }
         if list.isEqualOfIndex(0,1,2) {
             if list[0] == .enemy {
                 return (0, self.enemy.attack * 9 - self.userParameter.defense)
             } else {
-                attacks[AttributeType.allCases.firstIndex(of: list[0])!] = self.userParameter.attackPower(of: list[0]) * 9
+                attacks[AttributeType.allCases.firstIndex(of: list[0]!)!] = self.userParameter.attackPower(of: list[0]!) * 9
                 let playerPower = calculateAttribute(attacks: attacks).reduce(0) { $0 + $1 }
                 return (playerPower, 0)
             }
         }
         list.enumerated().forEach {
+            guard let item = $0.element else { return }
             guard $0.offset > 0 else {
-                attacks[AttributeType.allCases.firstIndex(of: $0.element)!] +=
-                    $0.element == .enemy ? self.enemy.attack : self.userParameter.attackPower(of: $0.element)
+                attacks[AttributeType.allCases.firstIndex(of: item)!] +=
+                    $0.element == .enemy ? self.enemy.attack : self.userParameter.attackPower(of: item)
                 return
             }
             if list.isEqualOfIndex($0.offset - 1, $0.offset) {
-                attacks[AttributeType.allCases.firstIndex(of: $0.element)!] +=
-                    $0.element == .enemy ? self.enemy.attack * 3 : self.userParameter.attackPower(of: $0.element) * 3
+                attacks[AttributeType.allCases.firstIndex(of: item)!] +=
+                    $0.element == .enemy ? self.enemy.attack * 3 : self.userParameter.attackPower(of: item) * 3
             } else {
-                attacks[AttributeType.allCases.firstIndex(of: $0.element)!] +=
-                    $0.element == .enemy ? self.enemy.attack : self.userParameter.attackPower(of: $0.element)
+                attacks[AttributeType.allCases.firstIndex(of: item)!] +=
+                    $0.element == .enemy ? self.enemy.attack : self.userParameter.attackPower(of: item)
             }
         }
         let enemyAttack = attacks.last!

--- a/slokara/slokara/Battle/BattleViewModel.swift
+++ b/slokara/slokara/Battle/BattleViewModel.swift
@@ -7,7 +7,6 @@ final class BattleViewModel {
     
     // ここはDBから取得する
     let reel = Reel(top: [true, true, true], center: [false, true, true], bottom: [true, false, true])
-    private let reelLine = ReelLine.triple
     private var userParameter: UserParameter!
     
     private var stage: Stage! {
@@ -82,7 +81,7 @@ final class BattleViewModel {
     }
     
     private func acceptAttack(results: [AttributeType?]) {
-        let attackPower = calculateAttackPower(result: results, line: self.reelLine)
+        let attackPower = calculateAttackPower(result: results, line: self.reel.lines)
         self.playerAttackRelay.accept(attackPower.player)
         
         // resultsを引き回さずに済むように、ここで敵の攻撃もacceptしておく。subscribe側でtoEnemyTurnをwithLatestFromする事で任意のタイミングで受け取れる

--- a/slokara/slokara/CustomViews/ReelView/ReelView.swift
+++ b/slokara/slokara/CustomViews/ReelView/ReelView.swift
@@ -11,16 +11,23 @@ class ReelView: UIView {
     @IBOutlet private weak var rightTopStone: UIView!
     @IBOutlet private weak var rightCenterStone: UIView!
     @IBOutlet private weak var rightBottomStone: UIView!
+    @IBOutlet private weak var topBackStackView: UIStackView!
+    @IBOutlet private weak var centerBackStackView: UIStackView!
+    @IBOutlet private weak var bottomBackStackView: UIStackView!
     
     private let disposeBag = DisposeBag()
-    private var reelChars = [ReelCharacter]()
+    private var reelChars = [ReelCharacter?]()
     private(set) var isAnimating = false
     
-    private var results = [AttributeType]()
-    private let reelStopEvent = PublishRelay<[AttributeType]>()
-    var reelStopped: Observable<[AttributeType]> { return reelStopEvent.asObservable() }
+    private var results = [AttributeType?]()
+    private let reelStopEvent = PublishRelay<[AttributeType?]>()
+    var reelStopped: Observable<[AttributeType?]> { return reelStopEvent.asObservable() }
     
-    var line: ReelLine? {
+    var reel: Reel? {
+        didSet { line = reel?.lines }
+    }
+    
+    private var line: ReelLine? {
         didSet { setUpFrame() }
     }
         
@@ -43,12 +50,13 @@ class ReelView: UIView {
     private func setUpFrame() {
         self.frameImageView.image = line?.frameImage
         addConstraints()
+        applyBackGrounds()
         addReelCharacters()
         bind()
     }
     
     private func bind() {
-        Observable.zip(self.reelChars.map{ $0.animationStoped }).subscribe(onNext: { [unowned self] _ in
+        Observable.zip(self.reelChars.compactMap{ $0?.animationStoped }).subscribe(onNext: { [unowned self] _ in
             guard self.isAnimating else { return }
             self.reelStopEvent.accept(self.results)
             self.isAnimating.toggle()
@@ -58,18 +66,17 @@ class ReelView: UIView {
     func startAnimation() {
         guard !self.isAnimating else { return }
         self.results.removeAll()
-        self.reelChars.enumerated().forEach { offset, element in
+        self.reelChars.compactMap{ $0 }.enumerated().forEach { offset, element in
             element.startAnimation(delay: Double(offset)/20)
         }
         self.isAnimating.toggle()
     }
     
-    func stopAnimation(results: [AttributeType]) {
+    func stopAnimation(results: [AttributeType?]) {
         guard self.isAnimating else { return }
-        guard results.count == self.line?.numberOfCharacter else { assert(false, "Reel lines dosen't match."); return }
         self.results = results
-        self.reelChars.enumerated().forEach { offset, element in
-            element.stopAnimation(result: results[offset], delay: Double(offset)/20)
+        self.reelChars.compactMap{ $0 }.enumerated().forEach { offset, element in
+            element.stopAnimation(result: results.compactMap{$0}[offset], delay: Double(offset)/20)
         }
     }
     
@@ -92,119 +99,74 @@ class ReelView: UIView {
         }
     }
     
-    private func addReelCharacters() {
-        let bottomReelCenter = ReelCharacter(frame: .zero)
-        bottomReelCenter.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(bottomReelCenter)
-        let bottomReelLeft = ReelCharacter(frame: .zero)
-        bottomReelLeft.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(bottomReelLeft)
-        let bottomReelRight = ReelCharacter(frame: .zero)
-        bottomReelRight.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(bottomReelRight)
-        self.reelChars.append(bottomReelLeft)
-        self.reelChars.append(bottomReelCenter)
-        self.reelChars.append(bottomReelRight)
+    private func applyBackGrounds() {
+        self.topBackStackView.isHidden = self.line != .triple
+        self.centerBackStackView.isHidden = self.line == .single
+        guard let reels = self.reel?.enableLines else { return }
+        reels.last?.enumerated().forEach { [weak self] offset, element in
+            self?.bottomBackStackView.subviews[offset].backgroundColor = element ? UIColor.white : UIColor.darkGray
+        }
         
-        let screenSize = UIScreen.main.bounds
-        bottomReelCenter.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
-        bottomReelCenter.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-        bottomReelCenter.heightAnchor.constraint(equalTo: bottomReelCenter.widthAnchor).isActive = true
-        bottomReelCenter.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -screenSize.width/13).isActive = true
-        bottomReelLeft.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-        bottomReelLeft.heightAnchor.constraint(equalTo: bottomReelLeft.widthAnchor).isActive = true
-        bottomReelLeft.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -screenSize.width/13).isActive = true
-        bottomReelLeft.trailingAnchor.constraint(equalTo: bottomReelCenter.leadingAnchor, constant: -screenSize.width/11).isActive = true
-        bottomReelRight.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-        bottomReelRight.heightAnchor.constraint(equalTo: bottomReelRight.widthAnchor).isActive = true
-        bottomReelRight.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -screenSize.width/13).isActive = true
-        bottomReelRight.leadingAnchor.constraint(equalTo: bottomReelCenter.trailingAnchor, constant: screenSize.width/11).isActive = true
-        
-        if self.line != ReelLine.single {
-            let middleReelCenter = ReelCharacter(frame: .zero)
-            middleReelCenter.translatesAutoresizingMaskIntoConstraints = false
-            self.addSubview(middleReelCenter)
-            let middleReelLeft = ReelCharacter(frame: .zero)
-            middleReelLeft.translatesAutoresizingMaskIntoConstraints = false
-            self.addSubview(middleReelLeft)
-            let middleReelRight = ReelCharacter(frame: .zero)
-            middleReelRight.translatesAutoresizingMaskIntoConstraints = false
-            self.addSubview(middleReelRight)
-            self.reelChars.insert(middleReelRight, at: 0)
-            self.reelChars.insert(middleReelCenter, at: 0)
-            self.reelChars.insert(middleReelLeft, at: 0)
-
-            
-            middleReelCenter.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
-            middleReelCenter.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-            middleReelCenter.heightAnchor.constraint(equalTo: middleReelCenter.widthAnchor).isActive = true
-            middleReelCenter.bottomAnchor.constraint(equalTo: bottomReelCenter.topAnchor, constant: -screenSize.width/12).isActive = true
-            middleReelLeft.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-            middleReelLeft.heightAnchor.constraint(equalTo: middleReelLeft.widthAnchor).isActive = true
-            middleReelLeft.bottomAnchor.constraint(equalTo: bottomReelLeft.topAnchor, constant: -screenSize.width/12).isActive = true
-            middleReelLeft.trailingAnchor.constraint(equalTo: middleReelCenter.leadingAnchor, constant: -screenSize.width/11).isActive = true
-            middleReelRight.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-            middleReelRight.heightAnchor.constraint(equalTo: middleReelRight.widthAnchor).isActive = true
-            middleReelRight.bottomAnchor.constraint(equalTo: bottomReelRight.topAnchor, constant: -screenSize.width/12).isActive = true
-            middleReelRight.leadingAnchor.constraint(equalTo: middleReelCenter.trailingAnchor, constant: screenSize.width/11).isActive = true
-            
-            
-            if self.line == ReelLine.triple {
-                let topReelCenter = ReelCharacter(frame: .zero)
-                topReelCenter.translatesAutoresizingMaskIntoConstraints = false
-                self.addSubview(topReelCenter)
-                let topReelLeft = ReelCharacter(frame: .zero)
-                topReelLeft.translatesAutoresizingMaskIntoConstraints = false
-                self.addSubview(topReelLeft)
-                let topReelRight = ReelCharacter(frame: .zero)
-                topReelRight.translatesAutoresizingMaskIntoConstraints = false
-                self.addSubview(topReelRight)
-                self.reelChars.insert(topReelRight, at: 0)
-                self.reelChars.insert(topReelCenter, at: 0)
-                self.reelChars.insert(topReelLeft, at: 0)
-                
-                topReelCenter.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
-                topReelCenter.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-                topReelCenter.heightAnchor.constraint(equalTo: topReelCenter.widthAnchor).isActive = true
-                topReelCenter.bottomAnchor.constraint(equalTo: middleReelCenter.topAnchor, constant: -screenSize.width/12).isActive = true
-                topReelLeft.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-                topReelLeft.heightAnchor.constraint(equalTo: topReelLeft.widthAnchor).isActive = true
-                topReelLeft.bottomAnchor.constraint(equalTo: middleReelLeft.topAnchor, constant: -screenSize.width/12).isActive = true
-                topReelLeft.trailingAnchor.constraint(equalTo: topReelCenter.leadingAnchor, constant: -screenSize.width/11).isActive = true
-                topReelRight.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1/6).isActive = true
-                topReelRight.heightAnchor.constraint(equalTo: topReelRight.widthAnchor).isActive = true
-                topReelRight.bottomAnchor.constraint(equalTo: middleReelRight.topAnchor, constant: -screenSize.width/12).isActive = true
-                topReelRight.leadingAnchor.constraint(equalTo: topReelCenter.trailingAnchor, constant: screenSize.width/11).isActive = true
+        if reels.count > 1 {
+            reels[reels.count-2].enumerated().forEach { [weak self] offset, element in
+                self?.centerBackStackView.subviews[offset].backgroundColor = element ? UIColor.white : UIColor.darkGray
             }
         }
         
-    }
-}
-
-enum ReelLine {
-    case single
-    case double
-    case triple
-    
-    var frameImage: UIImage? {
-        switch self {
-        case .single:
-            return UIImage(named: "reel_frame_single")
-        case .double:
-            return UIImage(named: "reel_frame_double")
-        case .triple:
-            return UIImage(named: "reel_frame_triple")
+        if reels.count > 2 {
+            reels.first?.enumerated().forEach { [weak self] offset, element in
+                self?.topBackStackView.subviews[offset].backgroundColor = element ? UIColor.white : UIColor.darkGray
+            }
         }
     }
     
-    var numberOfCharacter: Int {
-        switch self {
-        case .single:
-            return 3
-        case .double:
-            return 6
-        case .triple:
-            return 9
+    private func addReelCharacters() {
+        guard let reels = self.reel?.enableLines else { return }
+        
+        if reels.count > 2 {
+            reels.first?.enumerated().forEach { [weak self] offset, element in
+                guard element else { self?.reelChars.append(nil); return }
+                let char = ReelCharacter(frame: .zero)
+                char.translatesAutoresizingMaskIntoConstraints = false
+                guard let view = self?.topBackStackView.subviews[offset] else { return }
+                view.addSubview(char)
+                self?.reelChars.append(char)
+                
+                char.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+                char.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+                char.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7).isActive = true
+                char.heightAnchor.constraint(equalTo: char.widthAnchor).isActive = true
+            }
+        }
+        
+        if reels.count > 1 {
+            reels[reels.count-2].enumerated().forEach { [weak self] offset, element in
+                guard element else { self?.reelChars.append(nil); return }
+                let char = ReelCharacter(frame: .zero)
+                char.translatesAutoresizingMaskIntoConstraints = false
+                guard let view = self?.centerBackStackView.subviews[offset] else { return }
+                view.addSubview(char)
+                self?.reelChars.append(char)
+                
+                char.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+                char.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+                char.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7).isActive = true
+                char.heightAnchor.constraint(equalTo: char.widthAnchor).isActive = true
+            }
+        }
+        
+        reels.last?.enumerated().forEach { [weak self] offset, element in
+            guard element else { return }
+            let char = ReelCharacter(frame: .zero)
+            char.translatesAutoresizingMaskIntoConstraints = false
+            guard let view = self?.bottomBackStackView.subviews[offset] else { return }
+            view.addSubview(char)
+            self?.reelChars.append(char)
+            
+            char.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+            char.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+            char.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7).isActive = true
+            char.heightAnchor.constraint(equalTo: char.widthAnchor).isActive = true
         }
     }
 }

--- a/slokara/slokara/CustomViews/ReelView/ReelView.xib
+++ b/slokara/slokara/CustomViews/ReelView/ReelView.xib
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReelView" customModule="slokara" customModuleProvider="target">
             <connections>
+                <outlet property="bottomBackStackView" destination="Kwf-ZC-XLh" id="0R7-Ei-kLl"/>
+                <outlet property="centerBackStackView" destination="naJ-OC-zdD" id="DAh-ei-CmI"/>
                 <outlet property="frameImageView" destination="Sxy-SR-8o9" id="V9E-4u-OyA"/>
                 <outlet property="leftBottomStone" destination="uD0-5p-UFG" id="cFy-5W-yGa"/>
                 <outlet property="leftCenterStone" destination="6Ha-8x-jke" id="ask-zp-XAL"/>
@@ -17,6 +19,7 @@
                 <outlet property="rightBottomStone" destination="XOL-1r-CC9" id="ufn-gk-Dv7"/>
                 <outlet property="rightCenterStone" destination="57c-Wu-pZC" id="c2E-1R-Q8e"/>
                 <outlet property="rightTopStone" destination="qe1-Yr-6cU" id="uRO-9J-3JK"/>
+                <outlet property="topBackStackView" destination="Bnb-2f-LBG" id="N0X-Yv-9aF"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -54,6 +57,62 @@
                     <rect key="frame" x="0.0" y="158.5" width="72.5" height="50"/>
                     <color key="backgroundColor" red="0.20000000000000001" green="0.53333333333333333" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="GmS-ET-TfF">
+                    <rect key="frame" x="77.5" y="0.0" width="425" height="288"/>
+                    <subviews>
+                        <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Bnb-2f-LBG">
+                            <rect key="frame" x="0.0" y="0.0" width="425" height="0.0"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3I4-vd-7YK">
+                                    <rect key="frame" x="0.0" y="0.0" width="141.5" height="0.0"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D9v-MA-Dz8">
+                                    <rect key="frame" x="141.5" y="0.0" width="142" height="0.0"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9s5-Vb-9Wh">
+                                    <rect key="frame" x="283.5" y="0.0" width="141.5" height="0.0"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="naJ-OC-zdD">
+                            <rect key="frame" x="0.0" y="0.0" width="425" height="144"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FJV-Dg-SJ4">
+                                    <rect key="frame" x="0.0" y="0.0" width="141.5" height="144"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yqm-Us-ceN">
+                                    <rect key="frame" x="141.5" y="0.0" width="142" height="144"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d8w-q2-ype">
+                                    <rect key="frame" x="283.5" y="0.0" width="141.5" height="144"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Kwf-ZC-XLh">
+                            <rect key="frame" x="0.0" y="144" width="425" height="144"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="06r-HO-eru">
+                                    <rect key="frame" x="0.0" y="0.0" width="141.5" height="144"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bdg-18-dey">
+                                    <rect key="frame" x="141.5" y="0.0" width="142" height="144"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gk9-7l-ePy">
+                                    <rect key="frame" x="283.5" y="0.0" width="141.5" height="144"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                </stackView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reel_frame_double" translatesAutoresizingMaskIntoConstraints="NO" id="Sxy-SR-8o9">
                     <rect key="frame" x="0.0" y="0.0" width="580" height="308"/>
                 </imageView>
@@ -64,12 +123,14 @@
                 <constraint firstItem="6Ha-8x-jke" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="1:8" id="1k9-Hf-3mq"/>
                 <constraint firstItem="6Ha-8x-jke" firstAttribute="centerX" secondItem="t8H-lT-Jow" secondAttribute="centerX" id="2jX-ed-lt5"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="57c-Wu-pZC" secondAttribute="trailing" id="3e8-FU-mnZ"/>
+                <constraint firstAttribute="bottom" secondItem="GmS-ET-TfF" secondAttribute="bottom" constant="20" id="4lh-sT-MF9"/>
                 <constraint firstItem="57c-Wu-pZC" firstAttribute="width" secondItem="qe1-Yr-6cU" secondAttribute="width" id="7ve-hs-x5q"/>
                 <constraint firstItem="XOL-1r-CC9" firstAttribute="height" secondItem="57c-Wu-pZC" secondAttribute="height" multiplier="2:1" priority="750" id="Acp-rL-6i3"/>
                 <constraint firstItem="6Ha-8x-jke" firstAttribute="height" secondItem="t8H-lT-Jow" secondAttribute="height" multiplier="1:2" priority="750" id="Bd1-rd-9NV"/>
                 <constraint firstItem="57c-Wu-pZC" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="-8" id="DeD-gI-6TI"/>
                 <constraint firstItem="Sxy-SR-8o9" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Gre-ke-uUP"/>
                 <constraint firstAttribute="bottom" secondItem="Sxy-SR-8o9" secondAttribute="bottom" id="HWy-dH-HYM"/>
+                <constraint firstItem="GmS-ET-TfF" firstAttribute="leading" secondItem="6Ha-8x-jke" secondAttribute="trailing" constant="5" id="JVu-BY-kxN"/>
                 <constraint firstItem="6Ha-8x-jke" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="OKP-a7-5cT"/>
                 <constraint firstItem="XOL-1r-CC9" firstAttribute="width" secondItem="57c-Wu-pZC" secondAttribute="width" id="QXO-h1-kAw"/>
                 <constraint firstItem="57c-Wu-pZC" firstAttribute="centerX" secondItem="qe1-Yr-6cU" secondAttribute="centerX" id="Rqp-5V-0NU"/>
@@ -78,9 +139,11 @@
                 <constraint firstItem="6Ha-8x-jke" firstAttribute="width" secondItem="t8H-lT-Jow" secondAttribute="width" id="T6s-iO-kJ4"/>
                 <constraint firstItem="57c-Wu-pZC" firstAttribute="height" secondItem="qe1-Yr-6cU" secondAttribute="height" multiplier="1:2" priority="750" id="XpB-2V-28f"/>
                 <constraint firstItem="57c-Wu-pZC" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="1:8" id="YKN-zF-yYw"/>
+                <constraint firstItem="57c-Wu-pZC" firstAttribute="leading" secondItem="GmS-ET-TfF" secondAttribute="trailing" constant="5" id="bID-3J-ew4"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Sxy-SR-8o9" secondAttribute="trailing" id="c4u-JL-E5S"/>
                 <constraint firstItem="6Ha-8x-jke" firstAttribute="top" secondItem="t8H-lT-Jow" secondAttribute="bottom" id="fPq-5u-TGb"/>
                 <constraint firstItem="uD0-5p-UFG" firstAttribute="height" secondItem="6Ha-8x-jke" secondAttribute="height" multiplier="2:1" priority="750" id="kST-BC-R6C"/>
+                <constraint firstItem="GmS-ET-TfF" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="kqB-rJ-LBq"/>
                 <constraint firstItem="uD0-5p-UFG" firstAttribute="top" secondItem="6Ha-8x-jke" secondAttribute="bottom" id="lOG-lf-FXg"/>
                 <constraint firstItem="uD0-5p-UFG" firstAttribute="width" secondItem="6Ha-8x-jke" secondAttribute="width" id="m4f-Q1-hEu"/>
                 <constraint firstItem="t8H-lT-Jow" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" id="mXq-gp-Djf"/>
@@ -94,7 +157,7 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="-817.39130434782612" y="-350.55803571428572"/>
+            <point key="canvasLocation" x="-817.5" y="-350.7042253521127"/>
         </view>
     </objects>
     <resources>

--- a/slokara/slokara/Extensions/Array+.swift
+++ b/slokara/slokara/Extensions/Array+.swift
@@ -5,3 +5,15 @@ extension Array where Element: Hashable {
         return Set(indexes.map { self[$0] }).count == 1
     }
 }
+
+extension Array {
+    func separate(of size: Int) -> [[Element]] {
+        var selfArray = self
+        var result = [[Element]]()
+        while selfArray.count > 0 {
+            result.append(Array(selfArray.prefix(size)))
+            selfArray = selfArray.suffix(selfArray.count - size)
+        }
+        return result
+    }
+}

--- a/slokara/slokara/Models/Reel.swift
+++ b/slokara/slokara/Models/Reel.swift
@@ -44,15 +44,4 @@ enum ReelLine {
             return UIImage(named: "reel_frame_triple")
         }
     }
-    
-    var numberOfCharacter: Int {
-        switch self {
-        case .single:
-            return 3
-        case .double:
-            return 6
-        case .triple:
-            return 9
-        }
-    }
 }

--- a/slokara/slokara/Models/Reel.swift
+++ b/slokara/slokara/Models/Reel.swift
@@ -1,0 +1,58 @@
+import UIKit
+
+struct Reel {
+    var top = [false, false, false]
+    var center = [false, false, false]
+    var bottom = [true, true, true]
+    
+    func isEmptyLine(_ line: [Bool]) -> Bool {
+        return !line.contains(true)
+    }
+    
+    var lines: ReelLine {
+        let lines = [top, center, bottom].map { $0.filter { $0 } }.filter { !$0.isEmpty }.count
+        switch lines {
+        case 1:
+            return .single
+        case 2:
+            return .double
+        case 3:
+            return .triple
+        default:
+            assert(false, "Out of index from reel lines.")
+        }
+    }
+    
+    var enableLines: [[Bool]] {
+        return [top, center, bottom].filter { $0.contains(true) }
+    }
+    
+}
+
+enum ReelLine {
+    case single
+    case double
+    case triple
+    
+    var frameImage: UIImage? {
+        switch self {
+        case .single:
+            return UIImage(named: "reel_frame_single")
+        case .double:
+            return UIImage(named: "reel_frame_double")
+        case .triple:
+            return UIImage(named: "reel_frame_triple")
+        }
+    }
+    
+    var numberOfCharacter: Int {
+        switch self {
+        case .single:
+            return 3
+        case .double:
+            return 6
+        case .triple:
+            return 9
+        }
+    }
+}

--- a/slokara/slokaraTests/Array+Test.swift
+++ b/slokara/slokaraTests/Array+Test.swift
@@ -25,4 +25,10 @@ class Array_Test: XCTestCase {
         XCTAssertFalse(list.isEqualOfIndex(0, 1, 2))
     }
 
+    func testArraySeparate() {
+        let array = [1, 1, 1, 2, 2, 2, 3, 3, 3]
+        let result = [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
+        
+        XCTAssertEqual(array.separate(of: 3), result)
+    }
 }

--- a/slokara/slokaraTests/ReelTest.swift
+++ b/slokara/slokaraTests/ReelTest.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import slokara
+
+class ReelTest: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testSingleLine() {
+        let reel = Reel(top: [false, false, false], center: [false, false, false], bottom: [true, true, true])
+        XCTAssertEqual(reel.lines, ReelLine.single)
+    }
+    
+    func testDoubleLine() {
+        let reel = Reel(top: [false, false, false], center: [true, false, false], bottom: [true, true, true])
+        XCTAssertEqual(reel.lines, ReelLine.double)
+    }
+    
+    func testDoubleLineFull() {
+        let reel = Reel(top: [false, false, false], center: [true, true, true], bottom: [true, true, true])
+        XCTAssertEqual(reel.lines, ReelLine.double)
+    }
+    
+    func testTripleLine() {
+        let reel = Reel(top: [false, true, false], center: [true, false, false], bottom: [true, true, true])
+        XCTAssertEqual(reel.lines, ReelLine.triple)
+    }
+    
+    func testTripleLineFull() {
+        let reel = Reel(top: [true, true, true], center: [true, true, true], bottom: [true, true, true])
+        XCTAssertEqual(reel.lines, ReelLine.triple)
+    }
+    
+    func testEnableLineMin() {
+        let enableLines = Reel(top: [true, true, true], center: [false, false, false], bottom: [false, false, false]).enableLines
+        let result = [[true, true, true]]
+        XCTAssertEqual(enableLines, result)
+    }
+    
+    func testEnableLineDoublea() {
+        let enableLines = Reel(top: [true, true, true], center: [true, false, false], bottom: [false, false, false]).enableLines
+        let result = [[true, true, true], [true, false, false]]
+        XCTAssertEqual(enableLines, result)
+    }
+    
+    func testEnableLineDouble2() {
+        let enableLines = Reel(top: [true, true, true], center: [true, true, true], bottom: [false, false, false]).enableLines
+        let result = [[true, true, true], [true, true, true]]
+        XCTAssertEqual(enableLines, result)
+    }
+    
+    func testEnableLineDouble3() {
+        let enableLines = Reel(top: [false, true, false], center: [true, true, true], bottom: [false, false, false]).enableLines
+        let result = [[false, true, false], [true, true, true]]
+        XCTAssertEqual(enableLines, result)
+    }
+    
+    func testEnableLineTriple() {
+        let enableLines = Reel(top: [true, true, true], center: [true, true, false], bottom: [true, false, false]).enableLines
+        let result = [[true, true, true], [true, true, false], [true, false, false]]
+        XCTAssertEqual(enableLines, result)
+    }
+}


### PR DESCRIPTION
## WHAT
リールの追加を一本ずつではなく、一コマずつにする対応

## WHY
一本ずつの対応だと2本→3本のギャップが大きすぎる為

## HOW
旧：縦横斜めのうち、3マスあるラインを有効ラインとみなす
新：縦横斜めのうち、連続して2マス以上並んでいるラインを有効ラインとみなす
