### PR TITLE
敵の攻撃に属性を追加

### DIFF
--- a/slokara/slokara.xcodeproj/project.pbxproj
+++ b/slokara/slokara.xcodeproj/project.pbxproj
@@ -263,7 +263,7 @@
 		6A8BEB7F244DD67A00142587 /* Reel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reel.swift; sourceTree = "<group>"; };
 		6A8BEB81244DDA5900142587 /* ReelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReelTest.swift; sourceTree = "<group>"; };
 		6A8BEBCA2451AA6900142587 /* slokara_dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = slokara_dev.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		6A8BEC132451B74A00142587 /* スロから_DEV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "スロから_DEV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A8BEC132451B74A00142587 /* スロから_adhoc.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "スロから_adhoc.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6ABF318923AF586A0014E0BD /* TaskListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListViewController.swift; sourceTree = "<group>"; };
 		6ABF318B23AF58780014E0BD /* TaskList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TaskList.storyboard; sourceTree = "<group>"; };
 		6ABF318D23AF59570014E0BD /* TaskListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListViewModel.swift; sourceTree = "<group>"; };
@@ -526,7 +526,7 @@
 				9821B3402378560400CF964D /* slokaraTests.xctest */,
 				9821B34B2378560400CF964D /* slokaraUITests.xctest */,
 				6A8BEBCA2451AA6900142587 /* slokara_dev.app */,
-				6A8BEC132451B74A00142587 /* スロから_DEV.app */,
+				6A8BEC132451B74A00142587 /* スロから_adhoc.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -672,7 +672,7 @@
 			);
 			name = slokara_adhoc;
 			productName = slokara;
-			productReference = 6A8BEC132451B74A00142587 /* スロから_DEV.app */;
+			productReference = 6A8BEC132451B74A00142587 /* スロから_adhoc.app */;
 			productType = "com.apple.product-type.application";
 		};
 		9821B3292378560300CF964D /* slokara */ = {
@@ -1325,7 +1325,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.continue-dev.slokara-adhoc";
-				PRODUCT_NAME = "スロから_DEV";
+				PRODUCT_NAME = "スロから_adhoc";
 				PROVISIONING_PROFILE_SPECIFIER = workout.wildcard.adhoc;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = ADHOC;
 				SWIFT_VERSION = 5.0;
@@ -1354,7 +1354,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.continue-dev.slokara-adhoc";
-				PRODUCT_NAME = "スロから_DEV";
+				PRODUCT_NAME = "スロから_adhoc";
 				PROVISIONING_PROFILE_SPECIFIER = workout.wildcard.adhoc;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = ADHOC;
 				SWIFT_VERSION = 5.0;

--- a/slokara/slokara/Battle/BattleModel.swift
+++ b/slokara/slokara/Battle/BattleModel.swift
@@ -27,7 +27,7 @@ final class BattleModelImpl: BattleModelProtocol {
     }
     
     var userParameter: Observable<UserParameter> {
-        return Observable.just(UserParameter(fireAttack: 5, waterAttack: 5, windAttack: 5, soilAttack: 5, lightAttack: 5, darknessAttack: 10, defense: 20, maxHp: 100))
+        return Observable.just(UserParameter(fireAttack: 5, waterAttack: 5, windAttack: 5, soilAttack: 5, lightAttack: 5, darknessAttack: 10, defense: 20, maxHp: 100, defenseType: []))
     }
     
     func culcUserHp(_ value: Int64) {

--- a/slokara/slokara/Battle/BattleViewModel.swift
+++ b/slokara/slokara/Battle/BattleViewModel.swift
@@ -125,7 +125,7 @@ final class BattleViewModel {
         let attackList = [topAttack, middleAttack, bottomAttack, leftAttack, centerAttack, rightAttack, leftDiagonalAttack, rightDiagonalAttack]
         let attacks = attackList.reduce((0, 0)) { ($0.0 + $1.0, $0.1 + $1.1) }
         let player = attacks.0 - self.enemy.defense
-        let enemyAttack = attacks.1 - self.userParameter.defense
+        let enemyAttack = applyEnemyAttributeType(enemyAttack: attacks.1) - self.userParameter.defense
 
         return (player > 0 ? player : 0, enemyAttack > 0 ? enemyAttack : 0)
     }
@@ -146,6 +146,21 @@ final class BattleViewModel {
             }
         }
         return attackList
+    }
+    
+    /*
+     敵の攻撃に属性をつけ、プレイヤーの属性を参照して敵の攻撃を算出する
+     */
+    private func applyEnemyAttributeType(enemyAttack: Int64) -> Int64 {
+        guard let enemyAttackType = enemy.attackType.randomElement() else { return enemyAttack }
+        guard !userParameter.defenseType.isEmpty else { return enemyAttack }
+        
+        if userParameter.defenseType.contains(enemyAttackType.unfavorable!) {
+            return Int64(Double(enemyAttack) * 0.8)
+        } else if enemyAttackType.advantageous!.filter(userParameter.defenseType.contains).count > 0 {
+            return Int64(Double(enemyAttack) * 1.2)
+        }
+        return enemyAttack
     }
     
     /*

--- a/slokara/slokara/Models/UserParameter.swift
+++ b/slokara/slokara/Models/UserParameter.swift
@@ -9,6 +9,7 @@ struct UserParameter {
     let darknessAttack: Int64
     let defense: Int64
     let maxHp: Int64
+    let defenseType: [AttributeType]
     
     func attackPower(of type: AttributeType) -> Int64 {
         switch type {


### PR DESCRIPTION
## WHAT
敵の攻撃に属性を追加し、プレイヤーの防御属性に応じて倍率計算を行う

## HOW
毎ターン、敵の攻撃の総合に対して、敵が持つ攻撃属性からランダムで一つを選択し、プレイヤーの持つ防御属性のうち一つでもプレイヤーが有利属性を持てば攻撃を0.8倍とし、有利属性を持たずに不利属性があれば1.2倍とする