### PR TITLE
リールのチューニング画面を追加

### DIFF
--- a/slokara/slokara.xcodeproj/project.pbxproj
+++ b/slokara/slokara.xcodeproj/project.pbxproj
@@ -191,6 +191,10 @@
 		6A8BEC8024597F3C00142587 /* TaskConfirm.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6A1C491323B9DE1F00261DF5 /* TaskConfirm.storyboard */; };
 		6A8BEC882459CF6500142587 /* EnemyImageCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8BEC872459CF6500142587 /* EnemyImageCollectionCell.swift */; };
 		6A8BEC892459CF6500142587 /* EnemyImageCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8BEC872459CF6500142587 /* EnemyImageCollectionCell.swift */; };
+		6A8BEC8C245BB9C500142587 /* TuningReel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6A8BEC8B245BB9C500142587 /* TuningReel.storyboard */; };
+		6A8BEC8D245BB9C600142587 /* TuningReel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6A8BEC8B245BB9C500142587 /* TuningReel.storyboard */; };
+		6A8BEC8F245BB9E400142587 /* TuningReelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8BEC8E245BB9E400142587 /* TuningReelViewController.swift */; };
+		6A8BEC90245BB9E400142587 /* TuningReelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8BEC8E245BB9E400142587 /* TuningReelViewController.swift */; };
 		6ABF318A23AF586A0014E0BD /* TaskListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABF318923AF586A0014E0BD /* TaskListViewController.swift */; };
 		6ABF318C23AF58780014E0BD /* TaskList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6ABF318B23AF58780014E0BD /* TaskList.storyboard */; };
 		6ABF318E23AF59570014E0BD /* TaskListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABF318D23AF59570014E0BD /* TaskListViewModel.swift */; };
@@ -295,6 +299,8 @@
 		6A8BEC8524597F3C00142587 /* スロから_adhoc.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "スロから_adhoc.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A8BEC8624597F3D00142587 /* slokara_dev copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "slokara_dev copy-Info.plist"; path = "/Users/sab_swiftlin/Desktop/Swift/ios-game/slokara/slokara_dev copy-Info.plist"; sourceTree = "<absolute>"; };
 		6A8BEC872459CF6500142587 /* EnemyImageCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnemyImageCollectionCell.swift; sourceTree = "<group>"; };
+		6A8BEC8B245BB9C500142587 /* TuningReel.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TuningReel.storyboard; sourceTree = "<group>"; };
+		6A8BEC8E245BB9E400142587 /* TuningReelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuningReelViewController.swift; sourceTree = "<group>"; };
 		6ABF318923AF586A0014E0BD /* TaskListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListViewController.swift; sourceTree = "<group>"; };
 		6ABF318B23AF58780014E0BD /* TaskList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TaskList.storyboard; sourceTree = "<group>"; };
 		6ABF318D23AF59570014E0BD /* TaskListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListViewModel.swift; sourceTree = "<group>"; };
@@ -503,6 +509,7 @@
 		6A8BEC1524570DD300142587 /* Tuning */ = {
 			isa = PBXGroup;
 			children = (
+				6A8BEC8A245BB99800142587 /* TuningReel */,
 				6A8BEC1624570DF800142587 /* TuningStage */,
 			);
 			path = Tuning;
@@ -523,6 +530,15 @@
 				6A8BEC322458A0F800142587 /* AttributeSelectView.swift */,
 			);
 			path = TuningStage;
+			sourceTree = "<group>";
+		};
+		6A8BEC8A245BB99800142587 /* TuningReel */ = {
+			isa = PBXGroup;
+			children = (
+				6A8BEC8B245BB9C500142587 /* TuningReel.storyboard */,
+				6A8BEC8E245BB9E400142587 /* TuningReelViewController.swift */,
+			);
+			path = TuningReel;
 			sourceTree = "<group>";
 		};
 		6ABF318823AF584C0014E0BD /* TaskList */ = {
@@ -850,6 +866,7 @@
 				6A8BEBB82451AA6900142587 /* Battle.storyboard in Resources */,
 				6A8BEC182457186500142587 /* TuningStage.storyboard in Resources */,
 				6A8BEBB92451AA6900142587 /* Oranienbaum.ttf in Resources */,
+				6A8BEC8C245BB9C500142587 /* TuningReel.storyboard in Resources */,
 				6A8BEBBA2451AA6900142587 /* TaskListCell.xib in Resources */,
 				6A8BEC302458A06F00142587 /* AttributeSelectView.xib in Resources */,
 				6A8BEBBB2451AA6900142587 /* Assets.xcassets in Resources */,
@@ -880,6 +897,7 @@
 				6A8BEC7024597F3C00142587 /* Battle.storyboard in Resources */,
 				6A8BEC7124597F3C00142587 /* TuningStage.storyboard in Resources */,
 				6A8BEC7224597F3C00142587 /* Oranienbaum.ttf in Resources */,
+				6A8BEC8D245BB9C600142587 /* TuningReel.storyboard in Resources */,
 				6A8BEC7324597F3C00142587 /* TaskListCell.xib in Resources */,
 				6A8BEC7424597F3C00142587 /* AttributeSelectView.xib in Resources */,
 				6A8BEC7524597F3C00142587 /* Assets.xcassets in Resources */,
@@ -1173,6 +1191,7 @@
 				6A8BEBAD2451AA6900142587 /* HomeModel.swift in Sources */,
 				6A8BEBAE2451AA6900142587 /* NavigationViewController.swift in Sources */,
 				6A8BEBAF2451AA6900142587 /* HomeViewModel.swift in Sources */,
+				6A8BEC8F245BB9E400142587 /* TuningReelViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1228,6 +1247,7 @@
 				6A8BEC6424597F3C00142587 /* HomeModel.swift in Sources */,
 				6A8BEC6524597F3C00142587 /* NavigationViewController.swift in Sources */,
 				6A8BEC6624597F3C00142587 /* HomeViewModel.swift in Sources */,
+				6A8BEC90245BB9E400142587 /* TuningReelViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/slokara/slokara/Battle/BattleModel.swift
+++ b/slokara/slokara/Battle/BattleModel.swift
@@ -4,6 +4,7 @@ import RealmSwift
 protocol BattleModelProtocol {
     var currentStage: Observable<Stage> { get }
     var userParameter: Observable<UserParameter> { get }
+    var reelStatus: Observable<Reel> { get }
     func culcUserHp(_ value: Int64)
 }
 
@@ -38,6 +39,19 @@ final class BattleModelImpl: BattleModelProtocol {
     
     var userParameter: Observable<UserParameter> {
         return Observable.just(UserParameter(fireAttack: 5, waterAttack: 5, windAttack: 5, soilAttack: 5, lightAttack: 5, darknessAttack: 10, defense: 20, maxHp: 100, defenseType: []))
+    }
+    
+    var reelStatus: Observable<Reel> {
+        #if !PROD
+        if UserDefaults.standard.bool(forKey: "tuningMode") {
+            if let json = UserDefaults.standard.data(forKey: "reel") {
+                guard let reel = try? JSONDecoder().decode(Reel.self, from: json) else { assert(false, "Reel decode failed.") }
+                return Observable.just(reel)
+            }
+        }
+        #endif
+        
+        return Observable.just(Reel(top: [true, true, true], center: [false, true, true], bottom: [true, false, true]))
     }
     
     func culcUserHp(_ value: Int64) {

--- a/slokara/slokara/Battle/BattleViewController.swift
+++ b/slokara/slokara/Battle/BattleViewController.swift
@@ -35,7 +35,7 @@ class BattleViewController: UIViewController, NavigationChildViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.reelView.reel = viewModel.reel //Reel(top: [true, true, true], center: [true, true, false], bottom: [false, false, false])
+        self.reelView.reel = viewModel.reel
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/slokara/slokara/Battle/BattleViewModel.swift
+++ b/slokara/slokara/Battle/BattleViewModel.swift
@@ -5,8 +5,7 @@ final class BattleViewModel {
     private let battleModel: BattleModelProtocol
     private let disposeBag = DisposeBag()
     
-    // ここはDBから取得する
-    let reel = Reel(top: [true, true, true], center: [false, true, true], bottom: [true, false, true])
+    var reel: Reel!
     private var userParameter: UserParameter!
     
     private var stage: Stage! {
@@ -64,6 +63,10 @@ final class BattleViewModel {
         
         self.battleModel.currentStage.subscribe(onNext: { [weak self] stage in
             self?.stage = stage
+        }).disposed(by: disposeBag)
+        
+        self.battleModel.reelStatus.subscribe(onNext: { [weak self] reel in
+            self?.reel = reel
         }).disposed(by: disposeBag)
         
         reelStoped.subscribe(onNext: { [weak self] results in

--- a/slokara/slokara/CustomViews/ToggleButton.swift
+++ b/slokara/slokara/CustomViews/ToggleButton.swift
@@ -13,7 +13,7 @@ class ToggleButton: UIButton {
     
     private let fontName = "07LogoTypeGothic7"
 
-    private var isOn: Bool = false {
+    var isOn: Bool = false {
         didSet {
             let image = isOn ? self.selectedImage : self.normalImage
             self.setBackgroundImage(image, for: .normal)

--- a/slokara/slokara/Home/HomeViewController.swift
+++ b/slokara/slokara/Home/HomeViewController.swift
@@ -71,7 +71,7 @@ extension HomeViewController {
             print("FinalButtle")
             
             // 仮の画面遷移（遷移先がわかりやすい様にTOPのマージン部分を赤にしている）
-            let navigation = self.parent as! NavigationViewController
+            let navigation = me.parent as! NavigationViewController
             let homeVC = UIStoryboard(name: "Home", bundle: nil).instantiateInitialViewController() as! NavigationChildViewController
             homeVC.title = "ホーム"
             navigation.push(homeVC, animate: true)
@@ -84,7 +84,7 @@ extension HomeViewController {
             print("BossButtle")
             
             // 仮の画面遷移（前の画面に戻る）
-            let navigation = self.parent as! NavigationViewController
+            let navigation = me.parent as! NavigationViewController
             navigation.popViewController(animate: true)
         }
     }
@@ -98,6 +98,14 @@ extension HomeViewController {
     
     private var transitionToShop: Binder<Void> {
         return Binder(self) { me, _ in
+            #if !PROD
+            if UserDefaults.standard.bool(forKey: "tuningMode") {
+                let navigation = me.parent as! NavigationViewController
+                let tuningReelVC = UIStoryboard(name: "TuningReel", bundle: nil).instantiateInitialViewController() as! TuningReelViewController
+                navigation.push(tuningReelVC, animate: true)
+                return
+            }
+            #endif
             // TODO: TransitionToNextScreen
             print("Shop")
         }
@@ -112,7 +120,7 @@ extension HomeViewController {
     
     private var transitionToTask: Binder<Void> {
         return Binder(self) { me, _ in
-            let navigation = self.parent as! NavigationViewController
+            let navigation = me.parent as! NavigationViewController
             let taskListVC = UIStoryboard(name: "TaskList", bundle: nil).instantiateInitialViewController() as! NavigationChildViewController
             taskListVC.title = "課題リスト"
             navigation.push(taskListVC, animate: true)

--- a/slokara/slokara/Models/Reel.swift
+++ b/slokara/slokara/Models/Reel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-struct Reel {
+struct Reel: Codable {
     var top = [false, false, false]
     var center = [false, false, false]
     var bottom = [true, true, true]

--- a/slokara/slokara/Tuning/TuningReel/TuningReel.storyboard
+++ b/slokara/slokara/Tuning/TuningReel/TuningReel.storyboard
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sFc-Vh-Jk4">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Tuning Reel View Controller-->
+        <scene sceneID="AwJ-UY-PWV">
+            <objects>
+                <viewController id="sFc-Vh-Jk4" customClass="TuningReelViewController" customModule="slokara_dev" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="c72-ec-a75">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="62b-eC-kaz">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="T0r-Fy-0UA"/>
+                                </constraints>
+                            </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgJ-Dk-mn1">
+                                <rect key="frame" x="0.0" y="622" width="375" height="45"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="45" id="Mch-1F-MiK"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <state key="normal" title="確定"/>
+                                <state key="disabled">
+                                    <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="enterAction:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="wPb-G8-lU9"/>
+                                </connections>
+                            </button>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reel_frame_triple" translatesAutoresizingMaskIntoConstraints="NO" id="qNs-FZ-ZEV">
+                                <rect key="frame" x="0.0" y="331.5" width="375" height="290.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="qNs-FZ-ZEV" secondAttribute="height" multiplier="580:449" id="Xp7-aT-NVH"/>
+                                </constraints>
+                            </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GXW-K3-mdv" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="237" y="338" width="83.5" height="83.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="GXW-K3-mdv" secondAttribute="height" multiplier="1:1" id="Rgk-0L-nHY"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="w7N-Hi-6yJ"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iEk-VO-U0J" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="237" y="429.5" width="83.5" height="83"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="iEk-VO-U0J" secondAttribute="height" multiplier="1:1" id="axW-Ny-fQc"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="Kgj-UE-YdF"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="egd-7m-lQA" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="54.5" y="429.5" width="83.5" height="83"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="egd-7m-lQA" secondAttribute="height" multiplier="1:1" id="Z17-Zi-ycV"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="f3Z-Cw-OBR"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4eW-zO-glT" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="146" y="338" width="83" height="83.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="4eW-zO-glT" secondAttribute="height" multiplier="1:1" id="ZnD-Gj-Bvx"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="Yjm-Ln-qpZ"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I1j-ko-tKj" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="146" y="429.5" width="83" height="83"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="I1j-ko-tKj" secondAttribute="height" multiplier="1:1" id="jRe-Xf-OJK"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="QYP-89-iZU"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1k5-Bm-Mx6" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="54.5" y="520.5" width="83.5" height="83.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="1k5-Bm-Mx6" secondAttribute="height" multiplier="1:1" id="jqQ-xy-4Js"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="cv2-XU-fQD"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gxh-Mk-rDo" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="146" y="520.5" width="83" height="83.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="gxh-Mk-rDo" secondAttribute="height" multiplier="1:1" id="Vje-Tl-6QU"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="X5u-bQ-DfK"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nIj-k9-fJA" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="237" y="520.5" width="83.5" height="83.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="nIj-k9-fJA" secondAttribute="height" multiplier="1:1" id="4Qz-iG-4Mw"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="iRq-AS-CWy"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タップでリールの配置を設定してください" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Jb-V5-pNs">
+                                <rect key="frame" x="0.0" y="50" width="375" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="この画面はリリース版では表示されません" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMA-1S-rMG">
+                                <rect key="frame" x="0.0" y="71" width="375" height="14.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d8q-ma-xVp" customClass="ToggleButton" customModule="slokara_dev" customModuleProvider="target">
+                                <rect key="frame" x="54.5" y="338" width="83.5" height="83.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="d8q-ma-xVp" secondAttribute="height" multiplier="1:1" id="Pp6-V8-UuW"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="image" keyPath="selectedImage" value="fire"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="charButtonTapped:" destination="sFc-Vh-Jk4" eventType="touchUpInside" id="q9d-cf-dsM"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="GXW-K3-mdv" firstAttribute="width" secondItem="4eW-zO-glT" secondAttribute="width" id="03E-JR-T7C"/>
+                            <constraint firstItem="I1j-ko-tKj" firstAttribute="centerY" secondItem="egd-7m-lQA" secondAttribute="centerY" id="2JN-sx-f0S"/>
+                            <constraint firstItem="iEk-VO-U0J" firstAttribute="width" secondItem="iEk-VO-U0J" secondAttribute="height" multiplier="1:1" id="3bb-z7-O6H"/>
+                            <constraint firstItem="ssw-i5-TlH" firstAttribute="trailing" secondItem="qNs-FZ-ZEV" secondAttribute="trailing" id="5Ev-Mg-Che"/>
+                            <constraint firstItem="nMA-1S-rMG" firstAttribute="leading" secondItem="ssw-i5-TlH" secondAttribute="leading" id="8X4-4u-Ebq"/>
+                            <constraint firstItem="iEk-VO-U0J" firstAttribute="width" secondItem="I1j-ko-tKj" secondAttribute="width" id="9Ah-cq-AQ5"/>
+                            <constraint firstItem="nIj-k9-fJA" firstAttribute="centerY" secondItem="gxh-Mk-rDo" secondAttribute="centerY" id="FBO-b6-63a"/>
+                            <constraint firstItem="gxh-Mk-rDo" firstAttribute="centerY" secondItem="1k5-Bm-Mx6" secondAttribute="centerY" id="GsI-lg-smi"/>
+                            <constraint firstItem="iEk-VO-U0J" firstAttribute="leading" secondItem="I1j-ko-tKj" secondAttribute="trailing" constant="8" id="HCu-uI-81F"/>
+                            <constraint firstItem="4eW-zO-glT" firstAttribute="centerY" secondItem="d8q-ma-xVp" secondAttribute="centerY" id="HNv-eJ-4jx"/>
+                            <constraint firstItem="gxh-Mk-rDo" firstAttribute="leading" secondItem="1k5-Bm-Mx6" secondAttribute="trailing" constant="8" id="HbP-Gr-IPE"/>
+                            <constraint firstItem="4eW-zO-glT" firstAttribute="centerX" secondItem="c72-ec-a75" secondAttribute="centerX" id="Hvr-dk-5pp"/>
+                            <constraint firstItem="I1j-ko-tKj" firstAttribute="width" secondItem="I1j-ko-tKj" secondAttribute="height" multiplier="1:1" id="Jbf-nH-qrv"/>
+                            <constraint firstItem="I1j-ko-tKj" firstAttribute="width" secondItem="egd-7m-lQA" secondAttribute="width" id="RSB-qk-bRp"/>
+                            <constraint firstItem="gxh-Mk-rDo" firstAttribute="width" secondItem="qNs-FZ-ZEV" secondAttribute="width" multiplier="2:9" id="S7l-eC-NJZ"/>
+                            <constraint firstItem="ssw-i5-TlH" firstAttribute="trailing" secondItem="xgJ-Dk-mn1" secondAttribute="trailing" id="TbS-4O-5vf"/>
+                            <constraint firstItem="GXW-K3-mdv" firstAttribute="centerY" secondItem="4eW-zO-glT" secondAttribute="centerY" id="UkE-AZ-88k"/>
+                            <constraint firstItem="I1j-ko-tKj" firstAttribute="top" secondItem="4eW-zO-glT" secondAttribute="bottom" constant="8" id="WhG-1c-krj"/>
+                            <constraint firstItem="I1j-ko-tKj" firstAttribute="leading" secondItem="egd-7m-lQA" secondAttribute="trailing" constant="8" id="XLk-dg-V3n"/>
+                            <constraint firstItem="4eW-zO-glT" firstAttribute="width" secondItem="d8q-ma-xVp" secondAttribute="width" id="YG0-Pb-0iT"/>
+                            <constraint firstItem="xgJ-Dk-mn1" firstAttribute="leading" secondItem="ssw-i5-TlH" secondAttribute="leading" id="ZNH-9e-kN9"/>
+                            <constraint firstItem="ssw-i5-TlH" firstAttribute="trailing" secondItem="7Jb-V5-pNs" secondAttribute="trailing" id="ZPf-wb-eXs"/>
+                            <constraint firstItem="gxh-Mk-rDo" firstAttribute="width" secondItem="1k5-Bm-Mx6" secondAttribute="width" id="ZWW-5q-Etk"/>
+                            <constraint firstItem="GXW-K3-mdv" firstAttribute="leading" secondItem="4eW-zO-glT" secondAttribute="trailing" constant="8" id="aFs-xo-7Cd"/>
+                            <constraint firstItem="qNs-FZ-ZEV" firstAttribute="leading" secondItem="ssw-i5-TlH" secondAttribute="leading" id="bGv-fc-T5f"/>
+                            <constraint firstItem="xgJ-Dk-mn1" firstAttribute="top" secondItem="qNs-FZ-ZEV" secondAttribute="bottom" id="cLD-6L-yAd"/>
+                            <constraint firstItem="nMA-1S-rMG" firstAttribute="top" secondItem="7Jb-V5-pNs" secondAttribute="bottom" id="cQO-MR-Eh0"/>
+                            <constraint firstItem="7Jb-V5-pNs" firstAttribute="top" secondItem="62b-eC-kaz" secondAttribute="bottom" id="crl-H9-Lou"/>
+                            <constraint firstItem="ssw-i5-TlH" firstAttribute="bottom" secondItem="xgJ-Dk-mn1" secondAttribute="bottom" id="daa-1T-3p0"/>
+                            <constraint firstItem="gxh-Mk-rDo" firstAttribute="centerX" secondItem="c72-ec-a75" secondAttribute="centerX" id="f8h-Y4-4Oe"/>
+                            <constraint firstItem="I1j-ko-tKj" firstAttribute="centerX" secondItem="c72-ec-a75" secondAttribute="centerX" id="fOL-Ca-tZj"/>
+                            <constraint firstItem="nIj-k9-fJA" firstAttribute="width" secondItem="gxh-Mk-rDo" secondAttribute="width" id="fsS-Ww-wZj"/>
+                            <constraint firstAttribute="trailing" secondItem="nMA-1S-rMG" secondAttribute="trailing" id="hGZ-Cl-0w2"/>
+                            <constraint firstItem="62b-eC-kaz" firstAttribute="leading" secondItem="ssw-i5-TlH" secondAttribute="leading" id="hLo-yH-xfD"/>
+                            <constraint firstItem="xgJ-Dk-mn1" firstAttribute="top" secondItem="gxh-Mk-rDo" secondAttribute="bottom" constant="18" id="hrP-Az-L3g"/>
+                            <constraint firstItem="I1j-ko-tKj" firstAttribute="width" secondItem="4eW-zO-glT" secondAttribute="width" id="ivF-lD-jmG"/>
+                            <constraint firstItem="1k5-Bm-Mx6" firstAttribute="width" secondItem="1k5-Bm-Mx6" secondAttribute="height" multiplier="1:1" id="jiA-ZL-Z9m"/>
+                            <constraint firstItem="gxh-Mk-rDo" firstAttribute="top" secondItem="I1j-ko-tKj" secondAttribute="bottom" constant="8" id="k2M-dM-bec"/>
+                            <constraint firstItem="gxh-Mk-rDo" firstAttribute="width" secondItem="I1j-ko-tKj" secondAttribute="width" id="ly3-7e-F6y"/>
+                            <constraint firstItem="iEk-VO-U0J" firstAttribute="centerY" secondItem="I1j-ko-tKj" secondAttribute="centerY" id="o5g-0C-b16"/>
+                            <constraint firstItem="ssw-i5-TlH" firstAttribute="trailing" secondItem="62b-eC-kaz" secondAttribute="trailing" id="oTj-I3-mpE"/>
+                            <constraint firstItem="4eW-zO-glT" firstAttribute="width" secondItem="4eW-zO-glT" secondAttribute="height" multiplier="1:1" id="pNC-MD-Ude"/>
+                            <constraint firstItem="7Jb-V5-pNs" firstAttribute="leading" secondItem="ssw-i5-TlH" secondAttribute="leading" id="qDM-Md-9BJ"/>
+                            <constraint firstItem="d8q-ma-xVp" firstAttribute="width" secondItem="d8q-ma-xVp" secondAttribute="height" multiplier="1:1" id="rXy-gO-e3u"/>
+                            <constraint firstItem="egd-7m-lQA" firstAttribute="width" secondItem="egd-7m-lQA" secondAttribute="height" multiplier="1:1" id="sdP-sE-PbF"/>
+                            <constraint firstItem="62b-eC-kaz" firstAttribute="top" secondItem="ssw-i5-TlH" secondAttribute="top" id="sqD-xe-g7N"/>
+                            <constraint firstItem="nIj-k9-fJA" firstAttribute="width" secondItem="nIj-k9-fJA" secondAttribute="height" multiplier="1:1" id="ss6-Z0-idE"/>
+                            <constraint firstItem="nIj-k9-fJA" firstAttribute="leading" secondItem="gxh-Mk-rDo" secondAttribute="trailing" constant="8" id="toB-KK-qpI"/>
+                            <constraint firstItem="4eW-zO-glT" firstAttribute="leading" secondItem="d8q-ma-xVp" secondAttribute="trailing" constant="8" id="uoQ-bN-PAL"/>
+                            <constraint firstItem="GXW-K3-mdv" firstAttribute="width" secondItem="GXW-K3-mdv" secondAttribute="height" multiplier="1:1" id="xwC-Xe-Ecw"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ssw-i5-TlH"/>
+                    </view>
+                    <connections>
+                        <outlet property="bottomCenterCharButton" destination="gxh-Mk-rDo" id="ZZj-ta-tWQ"/>
+                        <outlet property="bottomLeftCharButton" destination="1k5-Bm-Mx6" id="iHQ-vW-vuR"/>
+                        <outlet property="bottomRightCharButton" destination="nIj-k9-fJA" id="VV7-hw-bPo"/>
+                        <outlet property="enterButton" destination="xgJ-Dk-mn1" id="Vd8-uN-rFX"/>
+                        <outlet property="middleCenterCharButton" destination="I1j-ko-tKj" id="8TR-wR-Ako"/>
+                        <outlet property="middleLeftCharButton" destination="egd-7m-lQA" id="W4J-KE-bvU"/>
+                        <outlet property="middleRightCharButton" destination="iEk-VO-U0J" id="2LS-vB-YQY"/>
+                        <outlet property="topCenterCharButton" destination="4eW-zO-glT" id="j1L-aY-SpD"/>
+                        <outlet property="topLeftCharButton" destination="d8q-ma-xVp" id="KBc-fU-arb"/>
+                        <outlet property="topRightCharButton" destination="GXW-K3-mdv" id="czB-uF-pNQ"/>
+                        <outlet property="topSpacer" destination="62b-eC-kaz" id="YDy-OO-cW1"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="wUk-mt-6bw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="39" y="131"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="fire" width="64" height="64"/>
+        <image name="reel_frame_triple" width="580" height="449"/>
+    </resources>
+</document>

--- a/slokara/slokara/Tuning/TuningReel/TuningReelViewController.swift
+++ b/slokara/slokara/Tuning/TuningReel/TuningReelViewController.swift
@@ -1,0 +1,60 @@
+import UIKit
+
+class TuningReelViewController: UIViewController, NavigationChildViewController {
+    @IBOutlet weak var topSpacer: UIView!
+    @IBOutlet private weak var topLeftCharButton: ToggleButton!
+    @IBOutlet private weak var topCenterCharButton: ToggleButton!
+    @IBOutlet private weak var topRightCharButton: ToggleButton!
+    @IBOutlet private weak var middleLeftCharButton: ToggleButton!
+    @IBOutlet private weak var middleCenterCharButton: ToggleButton!
+    @IBOutlet private weak var middleRightCharButton: ToggleButton!
+    @IBOutlet private weak var bottomLeftCharButton: ToggleButton!
+    @IBOutlet private weak var bottomCenterCharButton: ToggleButton!
+    @IBOutlet private weak var bottomRightCharButton: ToggleButton!
+    @IBOutlet weak var enterButton: UIButton!
+    
+    private var top: [ToggleButton] {
+        return [topLeftCharButton, topCenterCharButton, topRightCharButton]
+    }
+    
+    private var middle: [ToggleButton] {
+        return [middleLeftCharButton, middleCenterCharButton, middleRightCharButton]
+    }
+    
+    private var bottom: [ToggleButton] {
+        return [bottomLeftCharButton, bottomCenterCharButton, bottomRightCharButton]
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUp()
+    }
+    
+    private func setUp() {
+        guard let json =  UserDefaults.standard.data(forKey: "reel") else {
+            top.forEach{ $0.isOn = false }
+            middle.forEach{ $0.isOn = true }
+            bottom.forEach{ $0.isOn = false }
+            return
+        }
+        guard let reel = try? JSONDecoder().decode(Reel.self, from: json) else { assert(false, "Reel decode failed.") }
+        reel.top.enumerated().forEach{offset, element in top[offset].isOn = element }
+        reel.center.enumerated().forEach{offset, element in middle[offset].isOn = element }
+        reel.bottom.enumerated().forEach{offset, element in bottom[offset].isOn = element }
+    }
+    
+    @IBAction func enterAction(_ sender: Any) {
+        let reel = Reel(top: top.map{ $0.isOn }, center: middle.map{ $0.isOn }, bottom: bottom.map{ $0.isOn })
+        guard let json = try? JSONEncoder().encode(reel) else { assert(false, "Reel encode failed.") }
+        UserDefaults.standard.set(json, forKey: "reel")
+        
+        let navigation = self.parent as? NavigationViewController
+        navigation?.popViewController(animate: true)
+    }
+    
+    @IBAction func charButtonTapped(_ sender: Any) {
+        let chars: [Bool] = (top + middle + bottom).map{ $0.isOn }
+        self.enterButton.isEnabled = chars.contains(true)
+    }
+    
+}


### PR DESCRIPTION
## WHAT
チューニングモード時にリールのラインを設定できるようにする

## HOW
チューニングモードがオンの状態でホームの購買部からリール設定画面に遷移させる
設定可能なリールコマ数は1~9ライン(ただし、仕様上リールが2コマ以上並んでいないと有効ラインとはならないため注意)

## SCREEN
![Simulator Screen Shot - iPhone 11 - 2020-05-01 at 16 07 23](https://user-images.githubusercontent.com/50907353/80789062-dd8c5080-8bc5-11ea-90fc-45d0d03b1f0b.png)
